### PR TITLE
Do not shutdown on `SIGUSR1` to allow debugging

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -115,10 +115,6 @@ exports.register = function (server, _config) {
       shutdownSystem(err, 'SIGUSR2')
     })
 
-    process.on('SIGUSR1', (err) => {
-      shutdownSystem(err, 'SIGUSR1')
-    })
-
     process.on('unhandledRejection', (err) => {
       if (config.restartHapiOnUnhandledError) {
         shutdownSystem(err, 'unhandledRejection')


### PR DESCRIPTION
Node.js will start listening for debug connections when receiving a `SIGUSR1` signal, which currently doesn't work with this plugin, as it will shutdown on `SIGUSR1`.

See: https://nodejs.org/en/docs/guides/debugging-getting-started#enable-inspector